### PR TITLE
generic_algorithms: fix index error in reprioritize()

### DIFF
--- a/steinerpy/algorithms/unmerged.py
+++ b/steinerpy/algorithms/unmerged.py
@@ -4,7 +4,6 @@ from steinerpy.framework import Framework
 from .common import Common
 import steinerpy.config as cfg
 from steinerpy.library.animation import AnimateV2
-from steinerpy.library.search.generic_algorithms import GenericSearch
 from steinerpy.library.search.search_utils import reconstruct_path, CycleDetection
 from steinerpy.library.logger import MyLogger
 

--- a/steinerpy/library/search/generic_algorithms.py
+++ b/steinerpy/library/search/generic_algorithms.py
@@ -269,14 +269,14 @@ class GenericSearch(Search):
         This is easier than searching and updating every key
 
         """
-        # Create a new frontier structure
-        for o in self.frontier.entry_table:
+        # Modify frontier structure
+        for o in self.frontier.entry_table.copy():
             # make sure goal is not empty
             if self.goal:
                 # priority changes as a result of destination change. 
                 # Hence both fmin and pmin need to be updated
                 priority = self.fCosts(self, self.g, o)
-                self.frontier.put(o,priority)     
+                self.frontier.put(o, priority)     
                 self.fmin_heap.put(o, self.f[o])
 
 


### PR DESCRIPTION
As the frontier is being modified, it's best to iterate through a copy, without it, the README example fails with the error below

```
    for o in self.frontier.entry_table:
RuntimeError: dictionary keys changed during iteration
```
Test coverage improves as well, only 2 tests fail now